### PR TITLE
Add fix for ios to enable passcode backup

### DIFF
--- a/src/ios/Fingerprint.swift
+++ b/src/ios/Fingerprint.swift
@@ -23,13 +23,20 @@ import LocalAuthentication
     var reason = "Authentication";
     let data  = command.arguments[0] as AnyObject?;
 
+    var policy:LAPolicy;
+    if #available(iOS 9.0, *) {
+        policy = .deviceOwnerAuthentication;
+    } else {
+        policy = .deviceOwnerAuthenticationWithBiometrics;
+    }
+
     if let clientId = data?["clientId"] as! String? {
       reason = clientId;
     }
 
 
     authenticationContext.evaluatePolicy(
-      .deviceOwnerAuthenticationWithBiometrics,
+      policy,
       localizedReason: reason,
       reply: { [unowned self] (success, error) -> Void in
         if( success ) {


### PR DESCRIPTION
Added fix for ios to enable users to enter the
passcode in case the finger print authentication
fails. Otherwise, Enter passcode button is present
but no action is present on clicking the same